### PR TITLE
Make start script for docker retain JAVA_OPTS

### DIFF
--- a/bin/docker/run_metabase.sh
+++ b/bin/docker/run_metabase.sh
@@ -26,7 +26,7 @@ fi
 
 
 # Setup Java Options
-JAVA_OPTS="-Dlogfile.path=target/log -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -server"
+JAVA_OPTS="${JAVA_OPTS} -Dlogfile.path=target/log -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -server"
 
 if [ ! -z "$JAVA_TIMEZONE" ]; then
   JAVA_OPTS="${JAVA_OPTS} -Duser.timezone=${JAVA_TIMEZONE}"


### PR DESCRIPTION

###### TODO 
-  [ ] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).

The script was overriding JAVA_OPTS completely, which prevented users from passing options to the JVM.